### PR TITLE
Clarify hf adapter scope and usage

### DIFF
--- a/src/services/HFDataEngineAdapter.ts
+++ b/src/services/HFDataEngineAdapter.ts
@@ -1,9 +1,12 @@
 /**
  * HuggingFace Data Engine Adapter
  *
- * Adapts HuggingFace Data Engine responses to match the backend's expected format.
- * This service sits between the backend routes and the HF Data Engine Client,
- * ensuring compatibility with existing frontend expectations.
+ * HFDataEngineAdapter mediates between the HF Data Engine and internal services for supported endpoints.
+ * Unsupported operations return explicit NOT_IMPLEMENTED errors instead of falling back to fake data.
+ * See docs/hf-engine-scope.md and docs/data-flow.md for details.
+ *
+ * This adapter transforms HF Engine responses into the backend's expected format and provides
+ * a unified interface for controllers regardless of the underlying data source.
  */
 
 import { Logger } from '../core/Logger.js';
@@ -523,7 +526,7 @@ export class HFDataEngineAdapter {
       return this.getTopPrices(limit);
     }
 
-    // Intentional: see docs/hf-engine-scope.md – direct provider integrations are used; HF proxy endpoints are not part of this build.
+    // HF-based proxying for this provider is not implemented in this build; use direct provider clients instead.
     return {
       success: false,
       error: {
@@ -551,7 +554,7 @@ export class HFDataEngineAdapter {
       return this.getSystemHealth();
     }
 
-    // For Binance/KuCoin sources, return basic health with NOT_IMPLEMENTED note
+    // HF-based health checks for non-HF providers are not implemented in this build.
     return {
       success: true,
       data: {
@@ -575,7 +578,7 @@ export class HFDataEngineAdapter {
       return this.runSentimentAnalysis(text);
     }
 
-    // Intentional: see docs/hf-engine-scope.md – sentiment analysis is an HF-specific feature, not available via other providers.
+    // Sentiment analysis is an HF-specific feature; not available via other providers in this build.
     return {
       success: false,
       error: {

--- a/src/services/hf/HFAnalysisAdapter.ts
+++ b/src/services/hf/HFAnalysisAdapter.ts
@@ -1,8 +1,12 @@
 /**
  * HuggingFace Analysis Adapter
  *
- * Handles analysis-related routes (SMC, Elliott Wave, sentiment, etc.)
- * Note: Most technical analysis is done locally, but HF provides sentiment analysis
+ * HFAnalysisAdapter integrates HF-only analysis features.
+ * Core SMC and Elliott Wave analysis are performed by local analyzers, not HF.
+ * See docs/hf-engine-scope.md for the full responsibilities matrix.
+ *
+ * This adapter provides sentiment analysis via HF models, but advanced technical
+ * analysis (SMC, Elliott Wave) returns NOT_IMPLEMENTED as these are handled locally.
  */
 
 import { Logger } from '../../core/Logger.js';
@@ -108,13 +112,12 @@ export class HFAnalysisAdapter {
 
   /**
    * SMC (Smart Money Concepts) Analysis
-   * Note: This is typically done locally with technical indicators,
-   * but we provide a placeholder that returns NOT_IMPLEMENTED
+   * SMC analysis is intentionally handled by local analyzers, not the HF Data Engine.
    */
   async analyzeSMC(symbol: string, timeframe: string): Promise<AdapterResponse<any>> {
     const endpoint = '/analysis/smc';
 
-    // Intentional: see docs/hf-engine-scope.md – SMC/Elliott analysis runs via local analyzers, not HF Engine.
+    // SMC analysis is intentionally handled by local analyzers, not the HF Data Engine.
     return this.createError(
       endpoint,
       'SMC analysis via HuggingFace is not implemented. Use local technical analysis services.',
@@ -125,13 +128,12 @@ export class HFAnalysisAdapter {
 
   /**
    * Elliott Wave Analysis
-   * Note: This is typically done locally with pattern recognition,
-   * but we provide a placeholder that returns NOT_IMPLEMENTED
+   * Elliott Wave analysis is intentionally handled by local analyzers, not the HF Data Engine.
    */
   async analyzeElliott(symbol: string, timeframe: string): Promise<AdapterResponse<any>> {
     const endpoint = '/analysis/elliott';
 
-    // Intentional: see docs/hf-engine-scope.md – SMC/Elliott analysis runs via local analyzers, not HF Engine.
+    // Elliott Wave analysis is intentionally handled by local analyzers, not the HF Data Engine.
     return this.createError(
       endpoint,
       'Elliott Wave analysis via HuggingFace is not implemented. Use local technical analysis services.',

--- a/src/services/hf/HFMarketAdapter.ts
+++ b/src/services/hf/HFMarketAdapter.ts
@@ -1,8 +1,11 @@
 /**
  * HuggingFace Market Data Adapter
  *
- * Handles market-related routes and provides fallback to Binance/KuCoin
- * when PRIMARY_DATA_SOURCE = mixed
+ * HFMarketAdapter maps the HF Data Engine market endpoints into the internal market data model.
+ * It does not handle strategy logic, signals, or advanced analysis.
+ * See docs/hf-engine-scope.md and docs/data-flow.md for details.
+ *
+ * This is the primary adapter for market data: prices, OHLCV, tickers, and market overview.
  */
 
 import { Logger } from '../../core/Logger.js';

--- a/src/services/hf/HFProxyAdapter.ts
+++ b/src/services/hf/HFProxyAdapter.ts
@@ -1,8 +1,9 @@
 /**
  * HuggingFace Proxy Adapter
  *
- * Handles proxy routes for external data (news, fear & greed index, etc.)
- * HF Data Engine may aggregate news/sentiment from multiple sources
+ * HFProxyAdapter is a placeholder for potential proxy-style integrations via the HF Data Engine.
+ * In this build, direct provider clients are used instead; proxy methods are intentionally not implemented.
+ * See docs/hf-engine-scope.md for the current integration model.
  */
 
 import { Logger } from '../../core/Logger.js';
@@ -75,12 +76,12 @@ export class HFProxyAdapter {
 
   /**
    * Get cryptocurrency news
-   * Note: News aggregation via HF is not yet implemented
+   * This proxy method is intentionally not implemented; direct provider clients are used instead.
    */
   async getNews(symbol?: string, limit: number = 10): Promise<AdapterResponse<any[]>> {
     const endpoint = '/proxy/news';
 
-    // Intentional: see docs/hf-engine-scope.md – direct provider integrations are used; HF proxy endpoints are not part of this build.
+    // This proxy method is intentionally not implemented; direct provider clients are used instead.
     return this.createError(
       endpoint,
       'News aggregation via HuggingFace is not yet implemented. Use alternative news services.',
@@ -91,12 +92,12 @@ export class HFProxyAdapter {
 
   /**
    * Get Fear & Greed Index
-   * Note: Fear & Greed data via HF is not yet implemented
+   * This proxy method is intentionally not implemented; direct provider clients are used instead.
    */
   async getFearGreedIndex(): Promise<AdapterResponse<any>> {
     const endpoint = '/proxy/fear-greed';
 
-    // Intentional: see docs/hf-engine-scope.md – direct provider integrations are used; HF proxy endpoints are not part of this build.
+    // This proxy method is intentionally not implemented; direct provider clients are used instead.
     return this.createError(
       endpoint,
       'Fear & Greed Index via HuggingFace is not yet implemented. Use Alternative.me API.',
@@ -107,12 +108,12 @@ export class HFProxyAdapter {
 
   /**
    * Get social sentiment data
-   * Note: Could be implemented using HF sentiment models
+   * This proxy method is intentionally not implemented; direct provider clients are used instead.
    */
   async getSocialSentiment(symbol: string): Promise<AdapterResponse<any>> {
     const endpoint = '/proxy/social-sentiment';
 
-    // Intentional: see docs/hf-engine-scope.md – direct provider integrations are used; HF proxy endpoints are not part of this build.
+    // This proxy method is intentionally not implemented; direct provider clients are used instead.
     return this.createError(
       endpoint,
       'Social sentiment aggregation via HuggingFace is not yet implemented.',

--- a/src/services/hf/HFSignalsAdapter.ts
+++ b/src/services/hf/HFSignalsAdapter.ts
@@ -1,9 +1,12 @@
 /**
  * HuggingFace Signals Adapter
  *
- * Handles trading signal routes
- * Note: Signals are typically generated locally using technical analysis,
- * but this adapter provides integration points for HF-based signals
+ * HFSignalsAdapter is intentionally limited to basic HF integration.
+ * Signal generation, storage, and streaming are handled locally, not via the HF Data Engine.
+ * See docs/hf-engine-scope.md for details.
+ *
+ * This adapter exists as a placeholder for potential future HF-based signal features,
+ * but in the current build, all signal operations return NOT_IMPLEMENTED.
  */
 
 import { Logger } from '../../core/Logger.js';
@@ -76,7 +79,7 @@ export class HFSignalsAdapter {
 
   /**
    * Get signal history
-   * Note: Signals are typically stored locally, not in HF
+   * This operation is intentionally not implemented for HF; signals are managed locally.
    */
   async getSignalHistory(
     symbol?: string,
@@ -84,7 +87,7 @@ export class HFSignalsAdapter {
   ): Promise<AdapterResponse<any[]>> {
     const endpoint = '/signals/history';
 
-    // Intentional: see docs/hf-engine-scope.md – signals are generated and stored locally, not via HuggingFace.
+    // This operation is intentionally not implemented for HF; signals are managed locally.
     return this.createError(
       endpoint,
       'Signal history via HuggingFace is not implemented. Signals are stored locally.',
@@ -95,12 +98,12 @@ export class HFSignalsAdapter {
 
   /**
    * Get signals for a specific symbol
-   * Note: Signals are typically generated locally using technical analysis
+   * This operation is intentionally not implemented for HF; signals are managed locally.
    */
   async getSignalsForSymbol(symbol: string): Promise<AdapterResponse<any>> {
     const endpoint = `/signals/${symbol}`;
 
-    // Intentional: see docs/hf-engine-scope.md – signals are generated and stored locally, not via HuggingFace.
+    // This operation is intentionally not implemented for HF; signals are managed locally.
     return this.createError(
       endpoint,
       'Signal generation via HuggingFace is not implemented. Use local signal generation services.',
@@ -111,7 +114,7 @@ export class HFSignalsAdapter {
 
   /**
    * Analyze symbol and generate signals
-   * Note: This would require implementing ML-based signal generation in HF
+   * This operation is intentionally not implemented for HF; signals are managed locally.
    */
   async analyzeAndGenerateSignals(
     symbol: string,
@@ -119,7 +122,7 @@ export class HFSignalsAdapter {
   ): Promise<AdapterResponse<any>> {
     const endpoint = '/api/signals/analyze';
 
-    // Intentional: see docs/hf-engine-scope.md – signals are generated and stored locally, not via HuggingFace.
+    // This operation is intentionally not implemented for HF; signals are managed locally.
     return this.createError(
       endpoint,
       'ML-based signal generation via HuggingFace is not yet implemented.',


### PR DESCRIPTION
Add documentation to HuggingFace adapters to clarify their scope and intentional `NOT_IMPLEMENTED` features.

---
<a href="https://cursor.com/background-agent?bcId=bc-0460e53a-d6b6-4962-aa02-b47ed6e2a6a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0460e53a-d6b6-4962-aa02-b47ed6e2a6a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

