### PR TITLE
Add baseline tests for trading safety logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@vitest/coverage-v8": "^4.0.8",
         "autoprefixer": "^10.4.16",
         "concurrently": "^8.2.2",
+        "dotenv-cli": "^7.4.2",
         "esbuild": "^0.27.0",
         "eslint": "^9.0.0",
         "eslint-plugin-react-hooks": "^5.0.0",
@@ -3785,6 +3786,32 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-7.4.4.tgz",
+      "integrity": "sha512-XkBYCG0tPIes+YZr4SpfFv76SQrV/LeCE8CI7JSEMi3VR9MvTihCGTOtbIexD6i2mXF+6px7trb1imVCXSNMDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dunder-proto": {

--- a/src/engine/trading/__tests__/RiskGuard.test.ts
+++ b/src/engine/trading/__tests__/RiskGuard.test.ts
@@ -1,0 +1,153 @@
+/**
+ * RiskGuard Tests
+ *
+ * Tests the core risk checking logic:
+ * - Futures allowed trade
+ * - Futures blocked by position size
+ * - Futures blocked by missing market data
+ * - SPOT safety block
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { RiskGuard } from '../RiskGuard.js';
+import { ExchangeClient, AccountInfo, PositionResult } from '../../../services/exchange/ExchangeClient.js';
+import { Database } from '../../../data/Database.js';
+import { RiskCheckInput } from '../../../types/index.js';
+
+describe('RiskGuard', () => {
+  let riskGuard: RiskGuard;
+  let mockExchangeClient: {
+    getOpenPositions: ReturnType<typeof vi.fn>;
+    getAccountInfo: ReturnType<typeof vi.fn>;
+  };
+  let mockDatabase: {
+    getMarketData: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock ExchangeClient BEFORE getting RiskGuard instance
+    mockExchangeClient = {
+      getOpenPositions: vi.fn(),
+      getAccountInfo: vi.fn()
+    };
+    vi.spyOn(ExchangeClient, 'getInstance').mockReturnValue(mockExchangeClient as any);
+
+    // Mock Database BEFORE getting RiskGuard instance
+    mockDatabase = {
+      getMarketData: vi.fn()
+    };
+    vi.spyOn(Database, 'getInstance').mockReturnValue(mockDatabase as any);
+
+    // Reset singleton by accessing private instance (workaround for testing)
+    // Get fresh instance - it will use our mocks since they're set up first
+    (RiskGuard as any).instance = undefined;
+    riskGuard = RiskGuard.getInstance();
+  });
+
+  describe('Futures - Allowed Trade', () => {
+    it('should allow trade when all checks pass', async () => {
+      // Arrange: All values within limits
+      const input: RiskCheckInput = {
+        symbol: 'BTCUSDT',
+        side: 'BUY',
+        quantityUSDT: 100, // Below max (300)
+        market: 'FUTURES'
+      };
+
+      // Mock responses
+      mockExchangeClient.getOpenPositions.mockResolvedValue([
+        { symbol: 'ETHUSDT', side: 'LONG', size: 1 } as PositionResult
+      ]); // 1 position, below max (3)
+
+      mockExchangeClient.getAccountInfo.mockResolvedValue({
+        availableBalance: 1000, // Above min (50)
+        accountEquity: 10000, // For risk % calculation
+        unrealisedPNL: -10, // Above -maxDailyLoss (-100)
+        marginBalance: 1000
+      } as AccountInfo);
+
+      mockDatabase.getMarketData.mockResolvedValue([
+        { symbol: 'BTCUSDT', close: 50000, timestamp: Date.now() }
+      ]);
+
+      // Act
+      const result = await riskGuard.checkTradeRisk(input);
+
+      // Assert
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+  });
+
+  describe('Futures - Blocked by Position Size', () => {
+    it('should block trade when position size exceeds limit', async () => {
+      // Arrange: Position size exceeds max
+      const input: RiskCheckInput = {
+        symbol: 'BTCUSDT',
+        side: 'BUY',
+        quantityUSDT: 500, // Exceeds max (300)
+        market: 'FUTURES'
+      };
+
+      // Act
+      const result = await riskGuard.checkTradeRisk(input);
+
+      // Assert
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('exceeds max');
+      expect(result.reason).toContain('300'); // maxPositionSizeUSDT
+    });
+  });
+
+  describe('Futures - Blocked by Missing Market Data', () => {
+    it('should block trade when market data is required but unavailable', async () => {
+      // Arrange: Market data missing
+      const input: RiskCheckInput = {
+        symbol: 'BTCUSDT',
+        side: 'BUY',
+        quantityUSDT: 100, // Within limits
+        market: 'FUTURES'
+      };
+
+      // Mock responses
+      mockExchangeClient.getOpenPositions.mockResolvedValue([]);
+      mockExchangeClient.getAccountInfo.mockResolvedValue({
+        availableBalance: 1000,
+        accountEquity: 10000,
+        unrealisedPNL: -10,
+        marginBalance: 1000
+      } as AccountInfo);
+
+      // No market data available
+      mockDatabase.getMarketData.mockResolvedValue([]);
+
+      // Act
+      const result = await riskGuard.checkTradeRisk(input);
+
+      // Assert
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Market data unavailable');
+    });
+  });
+
+  describe('SPOT - Safety Block', () => {
+    it('should block SPOT trades for safety (balance verification not available)', async () => {
+      // Arrange: SPOT market
+      const input: RiskCheckInput = {
+        symbol: 'BTCUSDT',
+        side: 'BUY',
+        quantityUSDT: 100,
+        market: 'SPOT'
+      };
+
+      // Act
+      const result = await riskGuard.checkTradeRisk(input);
+
+      // Assert
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('SPOT balance verification not available');
+    });
+  });
+});

--- a/src/engine/trading/__tests__/TradeEngine.test.ts
+++ b/src/engine/trading/__tests__/TradeEngine.test.ts
@@ -3,201 +3,174 @@
  *
  * Tests the core trading execution engine with mocked ExchangeClient and RiskGuard.
  * Verifies:
- * - HOLD signals don't trigger trades
- * - Risk guard blocks are respected
- * - Successful trades are executed and saved
- * - Rejected orders are handled properly
+ * - Mode-aware execution (OFF, DRY_RUN, TESTNET)
+ * - Risk guard integration
+ * - ExchangeClient interaction
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TradeEngine } from '../TradeEngine.js';
+import { RiskGuard } from '../RiskGuard.js';
+import { ExchangeClient, PlaceOrderResult } from '../../../services/exchange/ExchangeClient.js';
+import { Database } from '../../../data/Database.js';
+import * as systemConfig from '../../../config/systemConfig.js';
+import { TradeSignal } from '../../../types/index.js';
 
 describe('TradeEngine', () => {
+  let tradeEngine: TradeEngine;
+  let mockRiskGuard: {
+    checkTradeRisk: ReturnType<typeof vi.fn>;
+    getConfig: ReturnType<typeof vi.fn>;
+  };
+  let mockExchangeClient: {
+    placeOrder: ReturnType<typeof vi.fn>;
+  };
+  let mockDatabase: {
+    getMarketData: ReturnType<typeof vi.fn>;
+    insert: ReturnType<typeof vi.fn>;
+  };
+
   beforeEach(() => {
-    // Clear all mocks before each test
     vi.clearAllMocks();
-  });
 
-  it('should skip execution for HOLD signals', async () => {
-    // Mock implementation would go here
-    // For now, we'll create a placeholder test
-
-    const signal = {
-      source: 'manual' as const,
-      symbol: 'BTCUSDT',
-      action: 'HOLD' as const,
-      confidence: null,
-      score: null,
-      timestamp: Date.now()
+    // Mock RiskGuard BEFORE getting TradeEngine instance
+    mockRiskGuard = {
+      checkTradeRisk: vi.fn(),
+      getConfig: vi.fn().mockReturnValue({
+        futures: { leverage: 3 },
+        spot: {}
+      })
     };
+    vi.spyOn(RiskGuard, 'getInstance').mockReturnValue(mockRiskGuard as any);
 
-    // In a real test, we'd import TradeEngine and execute the signal
-    // const result = await tradeEngine.executeSignal(signal);
-    // expect(result.executed).toBe(false);
-    // expect(result.reason).toContain('HOLD');
-
-    expect(signal.action).toBe('HOLD');
-  });
-
-  it('should block trades when risk guard denies', async () => {
-    // Mock RiskGuard to return allowed: false
-    // Mock ExchangeClient (should not be called)
-
-    const signal = {
-      source: 'manual' as const,
-      symbol: 'BTCUSDT',
-      action: 'BUY' as const,
-      confidence: 0.8,
-      score: 0.85,
-      timestamp: Date.now()
+    // Mock ExchangeClient BEFORE getting TradeEngine instance
+    mockExchangeClient = {
+      placeOrder: vi.fn()
     };
+    vi.spyOn(ExchangeClient, 'getInstance').mockReturnValue(mockExchangeClient as any);
 
-    // In a real test:
-    // const result = await tradeEngine.executeSignal(signal);
-    // expect(result.executed).toBe(false);
-    // expect(result.reason).toContain('blocked-by-risk-guard');
-
-    expect(signal.action).toBe('BUY');
-  });
-
-  it('should execute successful trades and save to database', async () => {
-    // Mock RiskGuard to return allowed: true
-    // Mock ExchangeClient to return success
-    // Mock Database.insert
-
-    const signal = {
-      source: 'strategy-pipeline' as const,
-      symbol: 'ETHUSDT',
-      action: 'SELL' as const,
-      confidence: 0.9,
-      score: 0.95,
-      timestamp: Date.now()
+    // Mock Database BEFORE getting TradeEngine instance
+    mockDatabase = {
+      getMarketData: vi.fn(),
+      insert: vi.fn().mockResolvedValue(undefined)
     };
+    vi.spyOn(Database, 'getInstance').mockReturnValue(mockDatabase as any);
 
-    // In a real test:
-    // const result = await tradeEngine.executeSignal(signal, 100);
-    // expect(result.executed).toBe(true);
-    // expect(result.order).toBeDefined();
-    // expect(result.order.status).toBe('FILLED');
-    // expect(mockDatabase.insert).toHaveBeenCalled();
+    // Mock system config functions
+    vi.spyOn(systemConfig, 'getTradingMode');
+    vi.spyOn(systemConfig, 'getTradingMarket');
 
-    expect(signal.action).toBe('SELL');
-  });
-
-  it('should handle rejected orders from exchange', async () => {
-    // Mock RiskGuard to return allowed: true
-    // Mock ExchangeClient to return REJECTED status
-
-    const signal = {
-      source: 'manual' as const,
-      symbol: 'BNBUSDT',
-      action: 'BUY' as const,
-      confidence: null,
-      score: null,
-      timestamp: Date.now()
-    };
-
-    // In a real test:
-    // const result = await tradeEngine.executeSignal(signal);
-    // expect(result.executed).toBe(false);
-    // expect(result.reason).toContain('Order rejected');
-    // expect(result.order?.status).toBe('REJECTED');
-
-    expect(signal.action).toBe('BUY');
-  });
-
-  it('should handle market data unavailability', async () => {
-    // Mock RiskGuard to return allowed: true
-    // Mock Database.getMarketData to return empty array
-
-    const signal = {
-      source: 'live-scoring' as const,
-      symbol: 'UNKNOWN',
-      action: 'BUY' as const,
-      confidence: 0.7,
-      score: 0.75,
-      timestamp: Date.now()
-    };
-
-    // In a real test:
-    // const result = await tradeEngine.executeSignal(signal);
-    // expect(result.executed).toBe(false);
-    // expect(result.reason).toContain('Market data unavailable');
-
-    expect(signal.symbol).toBe('UNKNOWN');
+    // Reset singleton instances to ensure fresh instances use our mocks
+    (TradeEngine as any).instance = undefined;
+    (RiskGuard as any).instance = undefined;
   });
 
   describe('Trading Mode Enforcement', () => {
     it('should block trades when trading mode is OFF', async () => {
-      // Mock getTradingMode to return 'OFF'
-      // Mock systemConfig to have modes.trading = 'OFF'
+      // Arrange: Mode is OFF
+      vi.mocked(systemConfig.getTradingMode).mockReturnValue('OFF');
+      vi.mocked(systemConfig.getTradingMarket).mockReturnValue('FUTURES');
 
-      const signal = {
-        source: 'manual' as const,
+      const signal: TradeSignal = {
+        source: 'manual',
         symbol: 'BTCUSDT',
-        action: 'BUY' as const,
+        action: 'BUY',
         confidence: 0.8,
         score: 0.85,
         timestamp: Date.now()
       };
 
-      // In a real test:
-      // const result = await tradeEngine.executeSignal(signal);
-      // expect(result.executed).toBe(false);
-      // expect(result.reason).toBe('trading-disabled');
-      // expect(result.market).toBe('FUTURES'); // or whatever market is configured
+      tradeEngine = TradeEngine.getInstance();
 
-      expect(signal.action).toBe('BUY');
+      // Act
+      const result = await tradeEngine.executeSignal(signal);
+
+      // Assert
+      expect(result.executed).toBe(false);
+      expect(result.reason).toBe('trading-disabled');
+      expect(mockExchangeClient.placeOrder).not.toHaveBeenCalled();
+      expect(mockRiskGuard.checkTradeRisk).not.toHaveBeenCalled();
     });
 
     it('should simulate trades in DRY_RUN mode without calling exchange', async () => {
-      // Mock getTradingMode to return 'DRY_RUN'
-      // Mock RiskGuard to return allowed: true
-      // Mock Database.getMarketData to return valid data
-      // Verify ExchangeClient.placeOrder is NOT called
-      // Verify order has 'DRY_' prefix in orderId
+      // Arrange: Mode is DRY_RUN, risk guard allows, market data available
+      vi.mocked(systemConfig.getTradingMode).mockReturnValue('DRY_RUN');
+      vi.mocked(systemConfig.getTradingMarket).mockReturnValue('FUTURES');
 
-      const signal = {
-        source: 'strategy-pipeline' as const,
+      mockRiskGuard.checkTradeRisk.mockResolvedValue({ allowed: true });
+      mockDatabase.getMarketData.mockResolvedValue([
+        { symbol: 'ETHUSDT', close: 3000, timestamp: Date.now() }
+      ]);
+
+      const signal: TradeSignal = {
+        source: 'strategy-pipeline',
         symbol: 'ETHUSDT',
-        action: 'SELL' as const,
+        action: 'SELL',
         confidence: 0.9,
         score: 0.95,
         timestamp: Date.now()
       };
 
-      // In a real test:
-      // const result = await tradeEngine.executeSignal(signal, 100);
-      // expect(result.executed).toBe(true);
-      // expect(result.order).toBeDefined();
-      // expect(result.order.orderId).toMatch(/^DRY_/);
-      // expect(result.order.status).toBe('FILLED');
-      // expect(mockExchangeClient.placeOrder).not.toHaveBeenCalled();
+      tradeEngine = TradeEngine.getInstance();
 
-      expect(signal.action).toBe('SELL');
+      // Act
+      const result = await tradeEngine.executeSignal(signal, 100);
+
+      // Assert
+      expect(result.executed).toBe(true);
+      expect(result.order).toBeDefined();
+      expect(result.order?.orderId).toMatch(/^DRY_FUTURES_/);
+      expect(result.order?.status).toBe('FILLED');
+      expect(mockExchangeClient.placeOrder).not.toHaveBeenCalled();
     });
 
-    it('should call exchange in TESTNET mode', async () => {
-      // Mock getTradingMode to return 'TESTNET'
-      // Mock RiskGuard to return allowed: true
-      // Mock ExchangeClient.placeOrder to return success
-      // Verify ExchangeClient.placeOrder IS called
+    it('should call exchange in TESTNET mode when risk passes', async () => {
+      // Arrange: Mode is TESTNET, risk guard allows, market data available
+      vi.mocked(systemConfig.getTradingMode).mockReturnValue('TESTNET');
+      vi.mocked(systemConfig.getTradingMarket).mockReturnValue('FUTURES');
 
-      const signal = {
-        source: 'live-scoring' as const,
+      mockRiskGuard.checkTradeRisk.mockResolvedValue({ allowed: true });
+      mockDatabase.getMarketData.mockResolvedValue([
+        { symbol: 'BTCUSDT', close: 50000, timestamp: Date.now() }
+      ]);
+
+      const mockOrderResult: PlaceOrderResult = {
+        orderId: 'test_order_123',
         symbol: 'BTCUSDT',
-        action: 'BUY' as const,
+        side: 'BUY',
+        quantity: 0.002,
+        status: 'FILLED',
+        price: 50000,
+        timestamp: Date.now()
+      };
+      mockExchangeClient.placeOrder.mockResolvedValue(mockOrderResult);
+
+      const signal: TradeSignal = {
+        source: 'live-scoring',
+        symbol: 'BTCUSDT',
+        action: 'BUY',
         confidence: 0.85,
         score: 0.9,
         timestamp: Date.now()
       };
 
-      // In a real test:
-      // const result = await tradeEngine.executeSignal(signal, 200);
-      // expect(result.executed).toBe(true);
-      // expect(mockExchangeClient.placeOrder).toHaveBeenCalled();
-      // expect(result.order?.orderId).not.toMatch(/^DRY_/);
+      tradeEngine = TradeEngine.getInstance();
 
-      expect(signal.action).toBe('BUY');
+      // Act
+      const result = await tradeEngine.executeSignal(signal, 100);
+
+      // Assert
+      expect(result.executed).toBe(true);
+      expect(mockExchangeClient.placeOrder).toHaveBeenCalledTimes(1);
+      expect(mockExchangeClient.placeOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbol: 'BTCUSDT',
+          side: 'BUY',
+          market: 'FUTURES'
+        })
+      );
+      expect(result.order?.orderId).toBe('test_order_123');
+      expect(result.order?.orderId).not.toMatch(/^DRY_/);
     });
   });
 


### PR DESCRIPTION
Introduce a minimal test baseline for `RiskGuard` and `TradeEngine` to lock in core trading safety and execution behavior.

These tests verify risk checks (e.g., position size, market data, SPOT safety) and trading mode enforcement (OFF, DRY_RUN, TESTNET), using Vitest and mocking external dependencies to prevent real API calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-702d52d2-be30-44b6-a2b6-be838b230109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-702d52d2-be30-44b6-a2b6-be838b230109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

