### PR TITLE
Migrate to hub-and-spoke frontend viewer

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4004,6 +4004,51 @@ const shutdown = () => {
 process.on('SIGINT', shutdown);
 process.on('SIGTERM', shutdown);
 
+// HUB PROXY ROUTES
+const getHubUrl = () => process.env.HF_ENGINE_BASE_URL || 'https://really-amin-datasourceforcryptocurrency.hf.space';
+
+// 1. Market Overview
+app.get('/api/market', async (req, res) => {
+    try {
+        const { limit = 50, symbol } = req.query;
+        const url = `${getHubUrl()}/api/market${symbol ? `?symbol=${symbol}` : `?limit=${limit}`}`;
+        const response = await axios.get(url, { timeout: 15000 });
+        res.json(response.data);
+    } catch (e) { res.json([]); }
+});
+
+// 2. OHLCV History
+app.get('/api/market/history', async (req, res) => {
+    try {
+        const { symbol, timeframe, limit } = req.query;
+        const url = `${getHubUrl()}/api/market/history?symbol=${symbol}&timeframe=${timeframe}&limit=${limit}`;
+        const response = await axios.get(url, { timeout: 15000 });
+        res.json(response.data);
+    } catch (e) { res.json([]); }
+});
+
+// 3. News Proxy
+app.get('/api/news/latest', async (req, res) => {
+    try {
+        const response = await axios.get(`${getHubUrl()}/api/news/latest`, { timeout: 10000 });
+        res.json(response.data);
+    } catch (e) { res.json([]); }
+});
+
+// 4. Stats & Sentiment
+app.get('/api/stats', async (req, res) => {
+    try {
+        const response = await axios.get(`${getHubUrl()}/api/stats`);
+        res.json(response.data);
+    } catch (e) { res.json({}); }
+});
+app.get('/api/sentiment', async (req, res) => {
+    try {
+        const response = await axios.get(`${getHubUrl()}/api/sentiment`);
+        res.json(response.data);
+    } catch (e) { res.json({ value: 50, classification: 'Neutral' }); }
+});
+
 // Start server with port collision prevention
 async function startServer() {
   try {

--- a/src/services/BinanceService.ts
+++ b/src/services/BinanceService.ts
@@ -1,79 +1,12 @@
-import axios, { AxiosInstance } from 'axios';
-import { createHmac } from 'crypto';
-import WebSocket from 'ws';
 import { MarketData } from '../types/index.js';
 import { Logger } from '../core/Logger.js';
-import { ConfigManager } from '../core/ConfigManager.js';
-
-interface RateLimitInfo {
-  requestsPerSecond: number;
-  requestsPerMinute: number;
-  dailyRequestCount: number;
-  lastResetTime: number;
-  requestQueue: number[];
-}
-
-interface ConnectionHealth {
-  isConnected: boolean;
-  lastPingTime: number;
-  latency: number;
-  averageLatency: number;
-  reconnectAttempts: number;
-  clockSkew: number;
-}
 
 export class BinanceService {
   private static instance: BinanceService;
-  private httpClient: AxiosInstance;
-  private wsConnections: Map<string, WebSocket> = new Map();
-  private wsMultiplexer: WebSocket | null = null;
-  private rateLimitInfo: RateLimitInfo;
-  private connectionHealth: ConnectionHealth;
-  private reconnectTimer: NodeJS.Timeout | null = null;
-  private healthCheckTimer: NodeJS.Timeout | null = null;
   private logger = Logger.getInstance();
-  private config = ConfigManager.getInstance();
-  private baseUrl: string;
-  private wsBaseUrl: string;
-  private testnetMode: boolean = true;
 
   private constructor() {
-    const binanceConfig = this.config.getBinanceConfig();
-    
-    this.testnetMode = binanceConfig.testnet;
-    this.baseUrl = this.testnetMode
-      ? 'https://testnet.binance.vision/api/v3'
-      : 'https://api.binance.com/api/v3';
-      
-    this.wsBaseUrl = this.testnetMode
-      ? 'wss://testnet.binance.vision/ws'
-      : 'wss://stream.binance.com:9443/ws';
-
-    this.rateLimitInfo = {
-      requestsPerSecond: 0,
-      requestsPerMinute: 0,
-      dailyRequestCount: 0,
-      lastResetTime: Date.now(),
-      requestQueue: []
-    };
-
-    this.connectionHealth = {
-      isConnected: false,
-      lastPingTime: 0,
-      latency: 0,
-      averageLatency: 0,
-      reconnectAttempts: 0,
-      clockSkew: 0
-    };
-
-    this.httpClient = axios.create({
-      baseURL: this.baseUrl,
-      timeout: 10000,
-    });
-
-    this.setupInterceptors();
-    this.startHealthMonitoring();
-    this.detectClockSkew();
+    this.logger.info('BinanceService initialized in DUMMY MODE');
   }
 
   static getInstance(): BinanceService {
@@ -83,288 +16,36 @@ export class BinanceService {
     return BinanceService.instance;
   }
 
-  private setupInterceptors(): void {
-    // Request interceptor for rate limiting and authentication
-    this.httpClient.interceptors.request.use(
-      async (config) => {
-        // Rate limiting check
-        await this.enforceRateLimit();
-        
-        const binanceConfig = this.config.getBinanceConfig();
-        
-        // Add timestamp and signature for authenticated endpoints
-        if (config.headers?.['X-REQUIRE-AUTH']) {
-          const timestamp = Date.now();
-          const queryString = new URLSearchParams(config.params).toString();
-          const signature = this.createSignature(queryString + `&timestamp=${timestamp}`);
-          
-          config.params = {
-            ...config.params,
-            timestamp,
-            signature
-          };
-          
-          config.headers['X-MBX-APIKEY'] = binanceConfig.apiKey;
-          delete config.headers['X-REQUIRE-AUTH'];
-        }
-        
-        return config;
-      },
-      (error) => {
-        this.logger.error('Request interceptor error', {}, error);
-        return Promise.reject(error);
-      }
-    );
-
-    // Response interceptor for error handling
-    this.httpClient.interceptors.response.use(
-      (response) => response,
-      (error) => {
-        // Handle rate limit errors
-        if (error.response?.status === 429) {
-          this.logger.warn('Rate limit exceeded, implementing backoff');
-          return this.handleRateLimitError(error);
-        }
-        
-        this.logger.error('Binance API error', {
-          status: error.response?.status,
-          statusText: error.response?.statusText,
-          data: error.response?.data
-        }, error);
-        return Promise.reject(error);
-      }
-    );
+  // Initialize method - returns immediately
+  async initialize(): Promise<void> {
+    this.logger.info('BinanceService dummy initialization complete');
+    return Promise.resolve();
   }
 
-  private async enforceRateLimit(): Promise<void> {
-    const now = Date.now();
-    const oneSecondAgo = now - 1000;
-    const oneMinuteAgo = now - 60000;
-    
-    // Clean old requests
-    this.rateLimitInfo.requestQueue = this.rateLimitInfo?.requestQueue?.filter(
-      timestamp => timestamp > oneMinuteAgo
-    );
-    
-    const recentRequests = this.rateLimitInfo?.requestQueue?.filter(
-      timestamp => timestamp > oneSecondAgo
-    );
-    
-    // Check rate limits
-    const binanceConfig = this.config.getBinanceConfig();
-    if ((recentRequests?.length || 0) >= binanceConfig.rateLimits.requestsPerSecond) {
-      const waitTime = 1000 - (now - recentRequests[0]);
-      await new Promise(resolve => setTimeout(resolve, waitTime));
-    }
-    
-    // Add current request to queue
-    this.rateLimitInfo.requestQueue.push(now);
-    this.rateLimitInfo.requestsPerSecond = recentRequests.length + 1;
-    this.rateLimitInfo.requestsPerMinute = this.rateLimitInfo.requestQueue.length;
+  // Detect clock skew - returns 0 immediately
+  async detectClockSkew(): Promise<number> {
+    this.logger.debug('Dummy clock skew detection returning 0');
+    return Promise.resolve(0);
   }
 
-  private async handleRateLimitError(error: any): Promise<any> {
-    const retryAfter = error.response?.headers['retry-after'] || 1;
-    const backoffTime = Math.min(retryAfter * 1000, 30000); // Max 30 seconds
-    
-    this.logger.warn(`Rate limited, backing off for ${backoffTime}ms`);
-    await new Promise(resolve => setTimeout(resolve, backoffTime));
-    
-    // Retry the original request
-    return this.httpClient.request(error.config);
+  // Get server time - returns current time
+  async getServerTime(): Promise<number> {
+    const currentTime = Date.now();
+    this.logger.debug(`Dummy server time returning: ${currentTime}`);
+    return Promise.resolve(currentTime);
   }
 
-  private async detectClockSkew(): Promise<void> {
-    try {
-      const localTime = Date.now();
-      const serverTime = await this.getServerTime();
-      this.connectionHealth.clockSkew = Math.abs(serverTime - localTime);
-      
-      if (this.connectionHealth.clockSkew > 1000) {
-        this.logger.warn('Clock skew detected', {
-          skew: this.connectionHealth.clockSkew,
-          localTime,
-          serverTime
-        });
-      }
-    } catch (error) {
-      this.logger.error('Failed to detect clock skew', {}, error as Error);
-    }
-  }
-
-  private startHealthMonitoring(): void {
-    this.healthCheckTimer = setInterval(async () => {
-      try {
-        const startTime = Date.now();
-        await this.testConnection();
-        this.connectionHealth.latency = Date.now() - startTime;
-        this.connectionHealth.isConnected = true;
-        this.connectionHealth.lastPingTime = Date.now();
-        this.connectionHealth.reconnectAttempts = 0;
-      } catch (error) {
-        this.connectionHealth.isConnected = false;
-        this.connectionHealth.reconnectAttempts++;
-        this.logger.error('Health check failed', {
-          attempts: this.connectionHealth.reconnectAttempts
-        }, error as Error);
-        
-        if (this.connectionHealth.reconnectAttempts >= 3) {
-          this.initiateReconnection();
-        }
-      }
-    }, 60000); // Check every 60 seconds (reduced from 30s to save API calls)
-  }
-
-  private initiateReconnection(): void {
-    if (this.reconnectTimer) return;
-    
-    const backoffTime = Math.min(
-      1000 * Math.pow(2, this.connectionHealth.reconnectAttempts),
-      300000 // Max 5 minutes
-    );
-    
-    this.logger.info('Initiating reconnection', { backoffTime });
-    
-    this.reconnectTimer = setTimeout(async () => {
-      try {
-        await this.testConnection();
-        this.connectionHealth.isConnected = true;
-        this.connectionHealth.reconnectAttempts = 0;
-        this.reconnectTimer = null;
-        this.logger.info('Reconnection successful');
-      } catch (error) {
-        this.reconnectTimer = null;
-        this.logger.error('Reconnection failed', {}, error as Error);
-      }
-    }, backoffTime);
-  }
-
-  // Toggle between testnet and mainnet
-  toggleTestnet(useTestnet: boolean): void {
-    if (this.testnetMode === useTestnet) return;
-    
-    this.testnetMode = useTestnet;
-    this.baseUrl = useTestnet
-      ? 'https://testnet.binance.vision/api/v3'
-      : 'https://api.binance.com/api/v3';
-      
-    this.wsBaseUrl = useTestnet
-      ? 'wss://testnet.binance.vision/ws'
-      : 'wss://stream.binance.com:9443/ws';
-    
-    // Update HTTP client base URL
-    this.httpClient.defaults.baseURL = this.baseUrl;
-    
-    // Close existing WebSocket connections
-    this.closeAllConnections();
-    
-    this.logger.info('Switched network mode', { testnet: useTestnet });
-  }
-
-  // WebSocket multiplexer for efficient connection management
-  private async createWebSocketMultiplexer(): Promise<WebSocket> {
-    if (this.wsMultiplexer && this.wsMultiplexer.readyState === WebSocket.OPEN) {
-      return this.wsMultiplexer;
-    }
-    
-    return new Promise((resolve, reject) => {
-      const ws = new WebSocket(`${this.wsBaseUrl}/!ticker@arr`);
-      
-      ws.on('open', () => {
-        this.logger.info('WebSocket multiplexer connected');
-        this.wsMultiplexer = ws;
-        this.connectionHealth.isConnected = true;
-        resolve(ws);
-      });
-      
-      ws.on('error', (error) => {
-        this.logger.error('WebSocket multiplexer error', {}, error);
-        this.connectionHealth.isConnected = false;
-        reject(error);
-      });
-      
-      ws.on('close', () => {
-        this.logger.info('WebSocket multiplexer disconnected');
-        this.wsMultiplexer = null;
-        this.connectionHealth.isConnected = false;
-        
-        // Auto-reconnect with exponential backoff
-        setTimeout(() => {
-          this.createWebSocketMultiplexer().catch(error => {
-            this.logger.error('Failed to reconnect multiplexer', {}, error);
-          });
-        }, Math.min(1000 * Math.pow(2, this.connectionHealth.reconnectAttempts), 30000));
-      });
-      
-      ws.on('message', (data) => {
-        try {
-          const message = JSON.parse(data.toString());
-          this.handleMultiplexerMessage(message);
-        } catch (error) {
-          this.logger.error('Failed to parse multiplexer message', {}, error as Error);
-        }
-      });
-      
-      // Connection timeout
-      setTimeout(() => {
-        if (ws.readyState === WebSocket.CONNECTING) {
-          ws.terminate();
-          reject(new Error('WebSocket multiplexer connection timeout'));
-        }
-      }, 10000);
+  // Get exchange info - returns empty object
+  async getExchangeInfo(): Promise<any> {
+    this.logger.debug('Dummy exchange info returning empty object');
+    return Promise.resolve({
+      timezone: 'UTC',
+      serverTime: Date.now(),
+      symbols: []
     });
   }
 
-  private handleMultiplexerMessage(message: any): void {
-    // Handle different types of multiplexed messages
-    if (Array.isArray(message)) {
-      // Ticker array data
-      message.forEach(ticker => {
-        this.logger.debug('Received ticker data', { symbol: ticker.s });
-      });
-    }
-  }
-
-  // Get connection health status
-  getConnectionHealth(): ConnectionHealth {
-    return { ...this.connectionHealth };
-  }
-
-  // Get rate limit information
-  getRateLimitInfo(): RateLimitInfo {
-    return { ...this.rateLimitInfo };
-  }
-
-  // Enhanced connection test with health metrics
-  async testConnection(): Promise<boolean> {
-    try {
-      const startTime = Date.now();
-      await this.httpClient.get('/ping');
-      this.connectionHealth.latency = Date.now() - startTime;
-      this.connectionHealth.isConnected = true;
-      this.connectionHealth.lastPingTime = Date.now();
-      this.logger.info('Binance connection test successful', {
-        latency: this.connectionHealth.latency,
-        testnet: this.testnetMode
-      });
-      return true;
-    } catch (error) {
-      this.connectionHealth.isConnected = false;
-      this.logger.error('Binance connection test failed', {
-        testnet: this.testnetMode
-      }, error as Error);
-      return false;
-    }
-  }
-
-  private createSignature(queryString: string): string {
-    const binanceConfig = this.config.getBinanceConfig();
-    return createHmac('sha256', binanceConfig.secretKey)
-      .update(queryString)
-      .digest('hex');
-  }
-
-  // Get historical OHLCV data
+  // Get historical OHLCV data - returns empty array
   async getKlines(
     symbol: string, 
     interval: string, 
@@ -372,215 +53,73 @@ export class BinanceService {
     startTime?: number,
     endTime?: number
   ): Promise<MarketData[]> {
-    try {
-      this.logger.info('Fetching klines data', { symbol, interval, limit });
-
-      const params: any = {
-        symbol: symbol.toUpperCase(),
-        interval,
-        limit
-      };
-
-      if (startTime) params.startTime = startTime;
-      if (endTime) params.endTime = endTime;
-
-      const response = await this.httpClient.get('/klines', { params });
-
-      const marketData: MarketData[] = (response.data || []).map((kline: any[]) => ({
-        symbol,
-        timestamp: kline[0], // Open time
-        open: parseFloat(kline[1]),
-        high: parseFloat(kline[2]),
-        low: parseFloat(kline[3]),
-        close: parseFloat(kline[4]),
-        volume: parseFloat(kline[5]),
-        interval
-      }));
-
-      this.logger.info('Successfully fetched klines data', { 
-        symbol, 
-        interval, 
-        count: marketData.length 
-      });
-
-      return marketData;
-
-    } catch (error) {
-      this.logger.error('Failed to fetch klines data', { symbol, interval }, error as Error);
-      throw error;
-    }
+    this.logger.debug(`Dummy klines request for ${symbol} returning empty array`);
+    return Promise.resolve([]);
   }
 
-  // Get current price for symbol
+  // Additional dummy methods that might be called
+  async testConnection(): Promise<boolean> {
+    this.logger.debug('Dummy connection test returning false');
+    return Promise.resolve(false);
+  }
+
   async getCurrentPrice(symbol: string): Promise<number> {
-    try {
-      const response = await this.httpClient.get('/ticker/price', {
-        params: { symbol: symbol.toUpperCase() }
-      });
-
-      return parseFloat(response.data.price);
-    } catch (error) {
-      this.logger.error('Failed to get current price', { symbol }, error as Error);
-      throw error;
-    }
+    this.logger.debug(`Dummy price for ${symbol} returning 0`);
+    return Promise.resolve(0);
   }
 
-  // Get 24hr ticker statistics
   async get24hrTicker(symbol?: string): Promise<any> {
-    try {
-      const params = symbol ? { symbol: symbol.toUpperCase() } : {};
-      const response = await this.httpClient.get('/ticker/24hr', { params });
-      return response.data;
-    } catch (error) {
-      this.logger.error('Failed to get 24hr ticker', { symbol }, error as Error);
-      throw error;
-    }
+    this.logger.debug('Dummy 24hr ticker returning empty object');
+    return Promise.resolve({});
   }
 
-  // WebSocket connection for real-time data
-  connectWebSocket(streams: string[]): Promise<WebSocket> {
-    return new Promise((resolve, reject) => {
-      const streamString = streams.join('/');
-      const wsUrl = `${this.wsBaseUrl}/${streamString}`;
-
-      if (this.wsConnections.has(streamString)) {
-        this.logger.info('Reusing existing WebSocket connection', { streams });
-        resolve(this.wsConnections.get(streamString)!);
-        return;
-      }
-
-      const ws = new WebSocket(wsUrl);
-
-      ws.on('open', () => {
-        this.logger.info('WebSocket connected', { streams });
-        this.wsConnections.set(streamString, ws);
-        resolve(ws);
-      });
-
-      ws.on('error', (error) => {
-        this.logger.error('WebSocket error', { streams }, error);
-        reject(error);
-      });
-
-      ws.on('close', () => {
-        this.logger.info('WebSocket disconnected', { streams });
-        this.wsConnections.delete(streamString);
-      });
-
-      ws.on('message', (data) => {
-        try {
-          const message = JSON.parse(data.toString());
-          this.handleWebSocketMessage(message);
-        } catch (error) {
-          this.logger.error('Failed to parse WebSocket message', { streams }, error as Error);
-        }
-      });
-
-      // Connection timeout
-      setTimeout(() => {
-        if (ws.readyState === WebSocket.CONNECTING) {
-          ws.terminate();
-          reject(new Error('WebSocket connection timeout'));
-        }
-      }, 10000);
-    });
-  }
-
-  private handleWebSocketMessage(message: any): void {
-    // Handle different types of WebSocket messages
-    if (message.e === 'kline') {
-      // Kline/Candlestick data
-      const kline = message.k;
-      const marketData: MarketData = {
-        symbol: kline.s,
-        timestamp: kline.t,
-        open: parseFloat(kline.o),
-        high: parseFloat(kline.h),
-        low: parseFloat(kline.l),
-        close: parseFloat(kline.c),
-        volume: parseFloat(kline.v),
-        interval: kline.i
-      };
-
-      // Emit event or store in database
-      this.logger.debug('Received kline data', { symbol: marketData.symbol });
-    }
-  }
-
-  // Subscribe to kline data stream
-  async subscribeToKlines(symbols: string[], interval: string = '1m'): Promise<WebSocket> {
-    const streams = (symbols || []).map(symbol => 
-      `${symbol.toLowerCase()}@kline_${interval}`
-    );
-    
-    return this.connectWebSocket(streams);
-  }
-
-  // Subscribe to ticker data stream
-  async subscribeToTickers(symbols: string[]): Promise<WebSocket> {
-    const streams = (symbols || []).map(symbol => 
-      `${symbol.toLowerCase()}@ticker`
-    );
-    
-    return this.connectWebSocket(streams);
-  }
-
-  // Get server time
-  async getServerTime(): Promise<number> {
-    try {
-      const response = await this.httpClient.get('/time');
-      return response.data.serverTime;
-    } catch (error) {
-      this.logger.error('Failed to get server time', {}, error as Error);
-      throw error;
-    }
-  }
-
-  // Close all WebSocket connections
   closeAllConnections(): void {
-    if (this.wsMultiplexer) {
-      this.wsMultiplexer.close();
-      this.wsMultiplexer = null;
-    }
-    
-    this.wsConnections.forEach((ws, stream) => {
-      this.logger.info('Closing WebSocket connection', { stream });
-      ws.close();
-    });
-    this.wsConnections.clear();
-    
-    if (this.healthCheckTimer) {
-      clearInterval(this.healthCheckTimer);
-      this.healthCheckTimer = null;
-    }
-    
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
+    this.logger.debug('Dummy close all connections - nothing to close');
   }
 
-  // Get account information (authenticated)
+  getConnectionHealth(): any {
+    return {
+      isConnected: false,
+      lastPingTime: 0,
+      latency: 0,
+      averageLatency: 0,
+      reconnectAttempts: 0,
+      clockSkew: 0
+    };
+  }
+
+  getRateLimitInfo(): any {
+    return {
+      requestsPerSecond: 0,
+      requestsPerMinute: 0,
+      dailyRequestCount: 0,
+      lastResetTime: Date.now(),
+      requestQueue: []
+    };
+  }
+
+  // Dummy WebSocket methods
+  async subscribeToKlines(symbols: string[], interval: string = '1m'): Promise<any> {
+    this.logger.debug('Dummy kline subscription - returning null');
+    return Promise.resolve(null);
+  }
+
+  async subscribeToTickers(symbols: string[]): Promise<any> {
+    this.logger.debug('Dummy ticker subscription - returning null');
+    return Promise.resolve(null);
+  }
+
+  connectWebSocket(streams: string[]): Promise<any> {
+    this.logger.debug('Dummy WebSocket connection - returning null');
+    return Promise.resolve(null);
+  }
+
+  toggleTestnet(useTestnet: boolean): void {
+    this.logger.debug(`Dummy testnet toggle to: ${useTestnet}`);
+  }
+
   async getAccountInfo(): Promise<any> {
-    try {
-      const response = await this.httpClient.get('/account', {
-        headers: { 'X-REQUIRE-AUTH': 'true' }
-      });
-      return response.data;
-    } catch (error) {
-      this.logger.error('Failed to get account info', {}, error as Error);
-      throw error;
-    }
-  }
-
-  // Get exchange info
-  async getExchangeInfo(): Promise<any> {
-    try {
-      const response = await this.httpClient.get('/exchangeInfo');
-      return response.data;
-    } catch (error) {
-      this.logger.error('Failed to get exchange info', {}, error as Error);
-      throw error;
-    }
+    this.logger.debug('Dummy account info returning empty object');
+    return Promise.resolve({});
   }
 }

--- a/src/services/MultiProviderMarketDataService.ts
+++ b/src/services/MultiProviderMarketDataService.ts
@@ -223,6 +223,21 @@ export class MultiProviderMarketDataService {
 
     const cacheKey = symbols.sort().join(',');
 
+    // Check if we should use the primary data source (HuggingFace proxy)
+    const primarySource = process.env.PRIMARY_DATA_SOURCE || 'huggingface';
+    if (primarySource === 'huggingface') {
+      try {
+        this.logger.info('Using HuggingFace proxy for market data');
+        const prices = await this.getPricesFromLocalProxy(symbols);
+        if (prices && prices.length > 0) {
+          this.priceCache.set(cacheKey, prices);
+          return prices;
+        }
+      } catch (error) {
+        this.logger.warn('Failed to get prices from HuggingFace proxy, falling back to other providers', error);
+      }
+    }
+
     // Use resource monitor to get recommended providers (smart prioritization)
     const recommendedProviders = this.resourceMonitor.getRecommendedProviders('market');
     
@@ -299,6 +314,41 @@ export class MultiProviderMarketDataService {
     console.error(errorMessage);
     // بازگشت آرایه خالی به جای throw error برای جلوگیری از crash
     return [];
+  }
+
+  /**
+   * Get prices from Local Proxy (HuggingFace)
+   */
+  private async getPricesFromLocalProxy(symbols: string[]): Promise<PriceData[]> {
+    try {
+      const baseUrl = process.env.VITE_API_BASE || 'http://localhost:8001';
+      
+      // For multiple symbols, make multiple requests
+      const pricePromises = symbols.map(async (symbol) => {
+        const response = await axios.get(`${baseUrl}/api/market`, {
+          params: { symbol: symbol.toUpperCase() },
+          timeout: 15000
+        });
+        
+        const data = Array.isArray(response.data) ? response.data : [response.data];
+        return data.map((item: any) => ({
+          symbol: item.symbol || symbol,
+          price: item.price || 0,
+          volume24h: item.volume24h || item.volume || 0,
+          change24h: item.change24h || 0,
+          changePercent24h: item.changePercent24h || item.change24h || 0,
+          marketCap: item.marketCap,
+          source: 'huggingface',
+          timestamp: Date.now()
+        }));
+      });
+      
+      const results = await Promise.all(pricePromises);
+      return results.flat();
+    } catch (error) {
+      this.logger.error('Failed to get prices from local proxy', error);
+      throw error;
+    }
   }
 
   /**

--- a/src/services/SentimentNewsService.ts
+++ b/src/services/SentimentNewsService.ts
@@ -100,6 +100,28 @@ export class SentimentNewsService {
     const cached = this.fearGreedCache.get('fear_greed');
     if (cached) return cached;
 
+    // Check if we should use the primary data source (HuggingFace proxy)
+    const primarySource = process.env.PRIMARY_DATA_SOURCE || 'huggingface';
+    if (primarySource === 'huggingface') {
+      try {
+        const baseUrl = process.env.VITE_API_BASE || 'http://localhost:8001';
+        const response = await axios.get(`${baseUrl}/api/sentiment`, {
+          timeout: 10000
+        });
+
+        const result: FearGreedIndex = {
+          value: response.data.value || 50,
+          classification: response.data.classification || 'Neutral',
+          timestamp: new Date()
+        };
+
+        this.fearGreedCache.set('fear_greed', result);
+        return result;
+      } catch (error) {
+        this.logger.warn('Failed to fetch sentiment from HuggingFace proxy, falling back to Alternative.me', {}, error as Error);
+      }
+    }
+
     await this.alternativeLimiter.wait();
 
     try {
@@ -140,6 +162,34 @@ export class SentimentNewsService {
     const cacheKey = `news_${limit}`;
     const cached = this.newsCache.get(cacheKey);
     if (cached) return cached;
+
+    // Check if we should use the primary data source (HuggingFace proxy)
+    const primarySource = process.env.PRIMARY_DATA_SOURCE || 'huggingface';
+    if (primarySource === 'huggingface') {
+      try {
+        const baseUrl = process.env.VITE_API_BASE || 'http://localhost:8001';
+        const response = await axios.get(`${baseUrl}/api/news/latest`, {
+          params: { limit },
+          timeout: 10000
+        });
+
+        const newsItems: NewsItem[] = (response.data || []).map((item: any) => ({
+          title: item.title || '',
+          url: item.url || '',
+          source: item.source || 'HuggingFace',
+          published: item.published ? new Date(item.published) : new Date(),
+          sentiment: item.sentiment || 'neutral',
+          sentimentScore: item.sentimentScore || 0
+        }));
+
+        if (newsItems.length > 0) {
+          this.newsCache.set(cacheKey, newsItems);
+          return newsItems;
+        }
+      } catch (error) {
+        this.logger.warn('Failed to fetch news from HuggingFace proxy, falling back to direct APIs', {}, error as Error);
+      }
+    }
 
     await this.cryptopanicLimiter.wait();
 


### PR DESCRIPTION
Convert the application to a pure frontend viewer by routing all data requests through a local proxy to a Hugging Face Hub, neutralizing legacy services, and updating configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-746229ed-8977-4c6f-85b7-f8003d0fbd34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-746229ed-8977-4c6f-85b7-f8003d0fbd34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

